### PR TITLE
`forwardRef` display name

### DIFF
--- a/src/hoa/mux_video/MuxVideo.jsx
+++ b/src/hoa/mux_video/MuxVideo.jsx
@@ -53,81 +53,80 @@ const getPoster = (video, { autoPlay }) => {
   return `https://image.mux.com/${video.playbackId}/thumbnail.jpg?${params}`
 }
 
-export const MuxVideo = React.forwardRef(
-  ({ autoPlay, video, ...props }, ref) => {
-    const localRef = useRef()
-    ref ||= localRef
+export const MuxVideo = React.forwardRef(function MuxVideoUnforwarded(
+  { autoPlay, video, ...props },
+  ref
+) {
+  const localRef = useRef()
+  ref ||= localRef
 
-    const [activeVideo, setActiveVideo] = useState(
-      !isArray(video) ? video : null
-    )
+  const [activeVideo, setActiveVideo] = useState(!isArray(video) ? video : null)
 
-    useEffect(() => {
-      if (isArray(video)) {
-        // `video` is an array of video objects with media queries. Chrome doesn't support the
-        // `media` attribute on a `<source>` element within a `<video>` element. Therefore, we need
-        // to use JS to find the matching video. This means that the browser won't be able to start
-        // downloading the video/poster until after our JS loads.
-        const updateActiveVideo = () => {
-          setActiveVideo(
-            video.find(({ media }) => window.matchMedia(media).matches)?.video
-          )
-        }
-
-        window.addEventListener("resize", updateActiveVideo)
-        updateActiveVideo()
-
-        return () => {
-          window.removeEventListener("resize", updateActiveVideo)
-        }
-      }
-    }, [video])
-
-    const poster = getPoster(activeVideo, { autoPlay })
-
-    useEffect(() => {
-      if (!activeVideo) {
-        return
+  useEffect(() => {
+    if (isArray(video)) {
+      // `video` is an array of video objects with media queries. Chrome doesn't support the
+      // `media` attribute on a `<source>` element within a `<video>` element. Therefore, we need
+      // to use JS to find the matching video. This means that the browser won't be able to start
+      // downloading the video/poster until after our JS loads.
+      const updateActiveVideo = () => {
+        setActiveVideo(
+          video.find(({ media }) => window.matchMedia(media).matches)?.video
+        )
       }
 
-      const result = initVideoPlayback({
-        // Safari has a bug when playing HLS videos in a loop so don't use native HLS with loops.
-        // https://mux.com/blog/mobile-safari-hls-bug-with-short-form-looping-videos/
-        allowNativeHls: !props.loop,
-        elem: ref.current,
-        playbackId: activeVideo.playbackId,
-        poster,
+      window.addEventListener("resize", updateActiveVideo)
+      updateActiveVideo()
+
+      return () => {
+        window.removeEventListener("resize", updateActiveVideo)
+      }
+    }
+  }, [video])
+
+  const poster = getPoster(activeVideo, { autoPlay })
+
+  useEffect(() => {
+    if (!activeVideo) {
+      return
+    }
+
+    const result = initVideoPlayback({
+      // Safari has a bug when playing HLS videos in a loop so don't use native HLS with loops.
+      // https://mux.com/blog/mobile-safari-hls-bug-with-short-form-looping-videos/
+      allowNativeHls: !props.loop,
+      elem: ref.current,
+      playbackId: activeVideo.playbackId,
+      poster,
+    })
+
+    // See https://docs.mux.com/guides/video/web-autoplay-your-videos
+    if (autoPlay) {
+      ref.current.play().catch(error => {
+        console.error("error while starting video playback", error)
       })
+    }
 
-      // See https://docs.mux.com/guides/video/web-autoplay-your-videos
-      if (autoPlay) {
-        ref.current.play().catch(error => {
-          console.error("error while starting video playback", error)
-        })
-      }
+    return result
+  }, [activeVideo?.playbackId])
 
-      return result
-    }, [activeVideo?.playbackId])
+  return (
+    <>
+      {isArray(video) && (
+        <>
+          <link rel="preconnect" href="https://image.mux.com" />
+          <link rel="preconnect" href="https://stream.mux.com" />
+        </>
+      )}
 
-    return (
-      <>
-        {isArray(video) && (
-          <>
-            <link rel="preconnect" href="https://image.mux.com" />
-            <link rel="preconnect" href="https://stream.mux.com" />
-          </>
-        )}
-
-        <video
-          {...getArWidthAndHeight(activeVideo)}
-          {...props}
-          poster={poster}
-          ref={ref}
-        />
-      </>
-    )
-  }
-)
+      <video
+        {...getArWidthAndHeight(activeVideo)}
+        {...props}
+        poster={poster}
+        ref={ref}
+      />
+    </>
+  )
+})
 
 MuxVideo.propTypes = {
   autoPlay: PropTypes.bool,

--- a/src/hoa/mux_video/MuxVideo.jsx
+++ b/src/hoa/mux_video/MuxVideo.jsx
@@ -53,7 +53,7 @@ const getPoster = (video, { autoPlay }) => {
   return `https://image.mux.com/${video.playbackId}/thumbnail.jpg?${params}`
 }
 
-export const MuxVideo = React.forwardRef(function MuxVideoUnforwarded(
+export const MuxVideo = React.forwardRef(function MuxVideo(
   { autoPlay, video, ...props },
   ref
 ) {


### PR DESCRIPTION
Fixes ESLint warning and makes the display name show up in React devtools.